### PR TITLE
Add `dnsmasq_server` variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ None of the variables below are required, but you need to at least set `dnsmasq_
 | `dnsmasq_option_router`  | -         | set this to specify the default gateway to be sent to clients.                                                                                                                         |
 | `dnsmasq_port`           | -         | set this to listen on a custom port.                                                                                                                                                   |
 | `dnsmasq_resolv_file`    | -         | set this to specify a custom `resolv.conf` file.                                                                                                                                       |
+| `dnsmasq_server`         | -         | set this to specify the IP address of upstream DNS servers directly.                                                                                                                   |
 
 ## Dependencies
 

--- a/templates/etc_dnsmasq.conf.j2
+++ b/templates/etc_dnsmasq.conf.j2
@@ -44,6 +44,10 @@ dhcp-host={{ host.mac }},{{ host.ip  }}{% if host.name is defined %},{{ host.nam
 dhcp-option=option:router,{{ dnsmasq_option_router }}
 {% endif %}
 
+{% if dnsmasq_server is defined %}
+server={{ dnsmasq_server }}
+{% endif %}
+
 {% if dnsmasq_authoritative %}
 dhcp-authoritative
 {% endif %}


### PR DESCRIPTION
Allows for specifying the IP address of the upstream DNS servers directly.
