### PR TITLE
Add ability to open dns port in specific firewalld zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ None of the variables below are required.
 | `dnsmasq_resolv_file`      | -       | Set this to specify a custom `resolv.conf` file.                                                                                                          |
 | `dnsmasq_upstream_servers` | -       | Set this to specify the IP address of upstream DNS servers directly. You can specify one ore more servers as a list.                                    |
 | `dnsmasq_srv_hosts`        | -       | Array of hashes specifying SRV records, with keys `name` (mandatory), `target`, `port`, `priority` and `weight` for each record. See below.              |
+| `firewalld_dns_zones`      | -       | Array of firewalld zones in which to allow inbound requests on DNS port (53/udp).                                                                        |
 
 ### DNS settings
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,4 @@ dnsmasq_domain_needed: false
 dnsmasq_bogus_priv: true
 dnsmasq_authoritative: false
 dnsmasq_expand_hosts: false
+firewalld_dns_zones: [public]

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,5 +7,5 @@
 
 - name: restart firewalld
   service:
-    name: dnsmasq
+    name: firewalld
     state: restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,3 +20,16 @@
     state: started
     enabled: yes
   tags: dnsmasq
+
+- name: Enable FirewallD DNS service
+  firewalld:
+    service: dns
+    zone: "{{ item }}"
+    permanent: true
+    immediate: true
+    state: enabled
+  notify:
+    - restart firewalld
+  with_items: "{{ firewalld_dns_zones | default([]) }}"
+  when: firewalld_dns_zones is defined
+  tags: dnsmasq


### PR DESCRIPTION
It's handy to have the ability to expose port 53/udp for DNS when standing up Dnsmasq. This PR adds the ability to expose that port in any FirewallD zone that is specified.