### PR TITLE
Add varaible dnsmasq_wildchar_address so it can do wildchar matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ None of the variables below are required.
 | `dnsmasq_resolv_file`      | -       | Set this to specify a custom `resolv.conf` file.                                                                                                          |
 | `dnsmasq_upstream_servers` | -       | Set this to specify the IP address of upstream DNS servers directly. You can specify one ore more servers as a list.                                    |
 | `dnsmasq_srv_hosts`        | -       | Array of hashes specifying SRV records, with keys `name` (mandatory), `target`, `port`, `priority` and `weight` for each record. See below.              |
+| `dnsmasq_wildchar_address`        | -       | Array of `address` to match wildchar dns matching              |
 
 ### DNS settings
 
@@ -57,6 +58,11 @@ SRV records (see [dnsmasq(8)](http://linux.die.net/man/8/dnsmasq) or [RFC 2782](
         port: 389
 ```
 
+Wildchar dns matching
+```Yaml
+    dnsmasq_wildchar_address:
+        - /apps.dev.example.com/192.168.122.130
+```
 ### DHCP settings
 
 A DHCP range can be specified with the variable `dnsmasq_dhcp_ranges`, e.g.:

--- a/templates/etc_dnsmasq.conf.j2
+++ b/templates/etc_dnsmasq.conf.j2
@@ -61,6 +61,7 @@ address= {{ dnsmasq_wildchar_address }}
 
 {% if dnsmasq_upstream_servers is defined %}
 {% if dnsmasq_upstream_servers is iterable %}
+all-servers
 {% for host in dnsmasq_upstream_servers %}
 server={{ host }}
 {% endfor %}

--- a/templates/etc_dnsmasq.conf.j2
+++ b/templates/etc_dnsmasq.conf.j2
@@ -49,6 +49,16 @@ dhcp-host={{ host.mac }},{{ host.ip  }}{% if host.name is defined %},{{ host.nam
 dhcp-option=option:router,{{ dnsmasq_option_router }}
 {% endif %}
 
+{% if dnsmasq_wildchar_address is defined %}
+{% if dnsmasq_wildchar_address is iterable %}
+{% for pattern in dnsmasq_wildchar_address %}
+address={{ pattern }}
+{% endfor %}
+{% else %}
+address= {{ dnsmasq_wildchar_address }}
+{% endif %}
+{% endif %}
+
 {% if dnsmasq_upstream_servers is defined %}
 {% if dnsmasq_upstream_servers is iterable %}
 {% for host in dnsmasq_upstream_servers %}


### PR DESCRIPTION
Hi, 
This is a small enhancement to add `address` function in dnsmasq conf template.
So it can configure the wildchar dns matching