### PR TITLE
Firewalld restart fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,3 +154,4 @@ Licensed under the 2-clause "Simplified BSD License". See [LICENSE.md](/LICENSE.
 - [Chris James](https://github.com/etcet)
 - [David Wittman](https://github.com/DavidWittman)
 - [Niklas Juslin](https://github.com/JZfi)
+- [Robin Peerlinck](https://github.com/DoctorPear)

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,5 +7,5 @@
 
 - name: restart firewalld
   service:
-    name: dnsmasq
+    name: firewalld
     state: restarted


### PR DESCRIPTION
Changes /handlers/main.yml to restart firewalld instead of restarting dnsmasq